### PR TITLE
Add resetBrowserState() per-spec browser cleanup helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+- add `resetBrowserState()` — per-spec browser cleanup for suites that share one browser across spec files. Call it in `afterEach`: it clears `localStorage`/`sessionStorage`, clears cookies (JS-visible sweep on the current origin plus a browser-context pass for HttpOnly), and navigates to `about:blank`. Two wins: (1) real cross-spec isolation (the shared-browser setup otherwise leaks storage/cookies between specs), and (2) the `about:blank` navigation cancels in-flight requests, releasing server-side resources (e.g. a pooled DB client) so server teardown isn't blocked. Best-effort and a no-op when there is no open page, so it can never fail an unrelated spec's teardown. The shared browser is left open and reusable.
+
 ## 3.0.1
 
 - patch vulnerable packages

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/psychic-spec-helpers",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "psychic framework spec helpers",
   "author": "RVO Health",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "psy": "NODE_ENV=${NODE_ENV:-test} tsx test-app/src/cli/index.ts",
     "uspec": "vitest --config ./spec/unit/vite.config.ts",
     "fspec": "vitest --config ./spec/features/vite.config.ts",
-    "build": "echo \"building psychic-spec-helpers...\" && rm -rf dist && npx tsc -p ./tsconfig.esm.build.json",
-    "build:test-app": "rm -rf dist && echo \"building test app to esm...\" && npx tsc -p ./tsconfig.esm.build.test-app.json && echo \"building test app to cjs...\" && npx tsc -p ./tsconfig.cjs.build.test-app.json",
+    "build": "echo \"building psychic-spec-helpers...\" && rm -rf dist && tsc -p ./tsconfig.esm.build.json",
+    "build:test-app": "rm -rf dist && echo \"building test app to esm...\" && tsc -p ./tsconfig.esm.build.test-app.json && echo \"building test app to cjs...\" && npx tsc -p ./tsconfig.cjs.build.test-app.json",
     "lint": "pnpm eslint --no-warn-ignored \"src/**/*.ts\" \"spec/**/*.ts\" && pnpm prettier . --check",
     "format": "pnpm prettier . --write",
     "prepack": "pnpm build"

--- a/spec/features/resetBrowserState.spec.ts
+++ b/spec/features/resetBrowserState.spec.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+// ^ this spec drives DOM globals (document/localStorage) inside page.evaluate;
+//   the spec tsconfig has no DOM lib, so they type as `any` here.
+import { resetBrowserState } from '../../src/index.js'
+
+describe('resetBrowserState', () => {
+  it('clears localStorage/sessionStorage and cookies and navigates to about:blank', async () => {
+    await visit('/')
+
+    await page.evaluate(() => {
+      localStorage.setItem('token', 'secret')
+      sessionStorage.setItem('flash', 'hi')
+      document.cookie = 'session=abc; path=/'
+    })
+
+    const before = (await page.evaluate(() => ({
+      ls: localStorage.getItem('token'),
+      cookie: document.cookie,
+    }))) as { ls: string | null; cookie: string }
+    expect(before.ls).toEqual('secret')
+    expect(before.cookie).toContain('session=abc')
+
+    await resetBrowserState()
+
+    expect(page.url()).toEqual('about:blank')
+
+    await visit('/')
+    const after = (await page.evaluate(() => ({
+      ls: localStorage.getItem('token'),
+      ss: sessionStorage.getItem('flash'),
+      cookie: document.cookie,
+    }))) as { ls: string | null; ss: string | null; cookie: string }
+    expect(after.ls).toBeNull()
+    expect(after.ss).toBeNull()
+    expect(after.cookie).not.toContain('session=abc')
+  })
+
+  it('is a no-op (does not throw) when there is no open page', async () => {
+    const original = (globalThis as { page?: unknown }).page
+    ;(globalThis as { page?: unknown }).page = undefined
+    try {
+      await expect(resetBrowserState()).resolves.toBeUndefined()
+    } finally {
+      ;(globalThis as { page?: unknown }).page = original
+    }
+  })
+})

--- a/spec/features/setup/hooks.ts
+++ b/spec/features/setup/hooks.ts
@@ -1,7 +1,7 @@
 import { Dream, DreamApp } from '@rvoh/dream'
 import { provideDreamViteMatchers, truncate } from '@rvoh/dream-spec-helpers'
 import { PsychicServer } from '@rvoh/psychic'
-import { providePuppeteerViteMatchers } from '../../../src/index.js'
+import { providePuppeteerViteMatchers, resetBrowserState } from '../../../src/index.js'
 import initializePsychicApp from '../../../test-app/src/cli/helpers/initializePsychicApp.js'
 import getPage from '../helpers/getPage.js'
 
@@ -38,6 +38,10 @@ beforeEach(async () => {
   await visit('/')
   await expect(page).toMatchTextContent('My div', { timeout: 10000 })
 }, 15000)
+
+afterEach(async () => {
+  await resetBrowserState()
+})
 
 afterAll(async () => {
   await server.stop()

--- a/src/feature/helpers/resetBrowserState.ts
+++ b/src/feature/helpers/resetBrowserState.ts
@@ -1,0 +1,66 @@
+import { Page } from 'puppeteer'
+
+async function bestEffort(fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn()
+  } catch (err) {
+    // Per-spec teardown must never throw: a failure cleaning one spec's state
+    // would fail an unrelated spec's `afterEach`. Swallow and move on.
+    void err
+  }
+}
+
+/**
+ * Per-spec browser cleanup for feature specs that share a single browser
+ * across spec files. Call in `afterEach` so every spec starts from a clean
+ * slate and so server-side resources are released between specs.
+ *
+ * Three best-effort steps, in this order:
+ *
+ *  1. Clear `localStorage` / `sessionStorage` for the current origin (auth
+ *     tokens, app state). Done first, while the page is still on the app
+ *     origin — storage is inaccessible once we navigate to `about:blank`.
+ *  2. Clear cookies for the page's browser context (context-scoped so
+ *     parallel contexts stay isolated).
+ *  3. Navigate to `about:blank`. Besides the clean slate, this cancels any
+ *     still-in-flight requests, releasing server-side resources they held
+ *     (e.g. a pooled database client) so server teardown isn't blocked.
+ *
+ * The shared browser is intentionally left open and reusable. Operates on
+ * the global `page`; a no-op if there is no open page.
+ */
+export default async function resetBrowserState(): Promise<void> {
+  const page = (globalThis as { page?: Page }).page
+  if (!page || page.isClosed()) return
+
+  if (/^https?:/.test(page.url())) {
+    await bestEffort(() =>
+      page.evaluate(() => {
+        localStorage.clear()
+        sessionStorage.clear()
+        // `document` isn't in the Node lib this package is type-checked
+        // against (localStorage/sessionStorage are), so reach it through a
+        // typed globalThis cast — it exists at runtime in the browser.
+        const { document } = globalThis as unknown as { document: { cookie: string } }
+        // Expire every JS-visible cookie on this origin. The browser-context
+        // cookie API below covers HttpOnly cookies, but does not reliably
+        // surface document.cookie-set cookies across every Puppeteer browser
+        // backend (notably Firefox/WebDriver-BiDi), so sweep here too.
+        for (const entry of document.cookie.split(';')) {
+          const eq = entry.indexOf('=')
+          const name = (eq > -1 ? entry.slice(0, eq) : entry).trim()
+          if (name) document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`
+        }
+      })
+    )
+  }
+
+  // Catches HttpOnly cookies (and any the JS sweep above could not reach).
+  await bestEffort(async () => {
+    const context = page.browserContext()
+    const cookies = await context.cookies()
+    if (cookies.length) await context.deleteCookie(...cookies)
+  })
+
+  await bestEffort(() => page.goto('about:blank'))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
 } from './feature/helpers/launchDevServer.js'
 export { default as launchPage } from './feature/helpers/launchPage.js'
 export { default as providePuppeteerViteMatchers } from './feature/helpers/providePuppeteerViteMatchers.js'
+export { default as resetBrowserState } from './feature/helpers/resetBrowserState.js'
 export { default as visit } from './feature/helpers/visit.js'
 
 declare global {


### PR DESCRIPTION
## Summary

Adds `resetBrowserState()` — a per-spec cleanup helper for feature-spec suites that share one browser across spec files (the scaffolded `hooks.ts` caches `global.page` and reuses it everywhere).

Call it in `afterEach`. Three best-effort steps, in order:

1. Clear `localStorage` / `sessionStorage` for the current origin (auth tokens, app state) — first, while still on the app origin (`about:blank` has no accessible storage).
2. Clear cookies: a JS-visible sweep on the current origin **plus** a browser-context pass for HttpOnly cookies (the context API alone does not reliably surface `document.cookie`-set cookies on Firefox/WebDriver-BiDi).
3. Navigate to `about:blank`.

## Why

Two independent problems, one helper:

- **Test isolation:** the shared-browser setup leaks `localStorage`/cookies between spec files. This makes isolation explicit.
- **Resource release at teardown:** the `about:blank` navigation cancels in-flight requests, releasing server-side resources they hold — notably a pooled DB client. Without it, `server.stop()`'s pool teardown can block until it times out (see rvohealth/dream#699, which bounds that drain; this avoids paying the bound at all).

Best-effort throughout and a no-op when there is no open page, so it can never fail an unrelated spec's teardown. The shared browser is left open and reusable. Dogfooded in this package's own fspec `hooks.ts` (`afterEach`) and covered by a new feature spec.

**Minor release `3.1.0`** — adds new exported functionality (`resetBrowserState`), so semver-minor, not patch.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm lint` — green (0 errors)
- [x] `pnpm fspec spec/features/resetBrowserState.spec.ts` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)