### PR TITLE
Clear pre-existing lint errors in src/security/index.ts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,18 @@ const config = typescriptEslint.config(
       parser: typescriptParser,
       parserOptions: { project: './tsconfig.json' },
     },
+    rules: {
+      // Honor the underscore-prefix convention the codebase already uses for
+      // intentionally-unused args/vars/caught errors (e.g. stub `_opts`).
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
   }
 )
 export default config

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,17 @@ export { OpenapiSpecSession } from './unit/OpenapiSpecSession.js'
 export { default as specRequest, SpecRequest } from './unit/SpecRequest.js'
 export { SpecSession } from './unit/SpecSession.js'
 
+// security audit helpers (stubs; implemented progressively by audit phases)
+export {
+  expectBlocksOpenRedirect,
+  expectNoMassAssignment,
+  forgeCookie,
+  mkPolyglotSvg,
+  mkProtoPollutionPayload,
+  type MassAssignmentAssertion,
+  type OpenRedirectAssertion,
+} from './security/index.js'
+
 // feature spec helpers
 export { default as launchBrowser } from './feature/helpers/launchBrowser.js'
 export {

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Security spec helpers for the Dream + Psychic security audit program.
+ *
+ * These helpers are intentionally unimplemented in this bootstrap phase.
+ * Later phases fill them in:
+ *   - Phase 1  → expectBlocksOpenRedirect
+ *   - Phase 3  → forgeCookie
+ *   - Phase 7  → expectNoMassAssignment, mkProtoPollutionPayload
+ *   - Phase 11 → mkPolyglotSvg
+ *
+ * Phase 2 (CSRF) was SKIPPED: Psychic's SameSite=Strict cookie default blocks
+ * classical CSRF at the browser layer for modern browsers, so no server-side
+ * CSRF-token primitive is shipped. See SECURITY_AUDIT_TRACKER.md R-002.
+ *
+ * Tracker: ~/work/dream_and_psychic/SECURITY_AUDIT_TRACKER.md
+ */
+
+function notImplemented(name: string): never {
+  throw new Error(
+    `${name} is a security-audit helper stub; implementation lands in a later audit phase. ` +
+      `See ~/work/dream_and_psychic/SECURITY_AUDIT_TRACKER.md.`,
+  )
+}
+
+export interface OpenRedirectAssertion {
+  /** The request-issuing callable whose response Location header must be inspected. */
+  request: () => Promise<{ status: number; headers: Record<string, string> }>
+  /** The attacker-controlled destination that should be rejected (e.g. 'https://evil.com'). */
+  maliciousTarget: string
+}
+
+export async function expectBlocksOpenRedirect(_opts: OpenRedirectAssertion): Promise<void> {
+  notImplemented('expectBlocksOpenRedirect')
+}
+
+export interface MassAssignmentAssertion {
+  /** Function that performs a create/update with attacker-controlled body. */
+  request: (body: Record<string, unknown>) => Promise<unknown>
+  /** Field the attacker is trying to set but should be filtered. */
+  protectedField: string
+  /** Value the attacker is trying to inject. */
+  maliciousValue: unknown
+  /** Function that reads back the persisted record for verification. */
+  readBack: () => Promise<Record<string, unknown>>
+}
+
+export async function expectNoMassAssignment(_opts: MassAssignmentAssertion): Promise<void> {
+  notImplemented('expectNoMassAssignment')
+}
+
+export function forgeCookie(_opts: { name: string; payload: unknown; secret?: string }): string {
+  return notImplemented('forgeCookie')
+}
+
+export function mkProtoPollutionPayload(): Record<string, unknown> {
+  return notImplemented('mkProtoPollutionPayload')
+}
+
+export function mkPolyglotSvg(): Buffer {
+  return notImplemented('mkPolyglotSvg')
+}

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -18,7 +18,7 @@
 function notImplemented(name: string): never {
   throw new Error(
     `${name} is a security-audit helper stub; implementation lands in a later audit phase. ` +
-      `See ~/work/dream_and_psychic/SECURITY_AUDIT_TRACKER.md.`,
+      `See ~/work/dream_and_psychic/SECURITY_AUDIT_TRACKER.md.`
   )
 }
 
@@ -29,7 +29,10 @@ export interface OpenRedirectAssertion {
   maliciousTarget: string
 }
 
-export async function expectBlocksOpenRedirect(_opts: OpenRedirectAssertion): Promise<void> {
+// Not `async`: the body only throws (stub). The `Promise<void>` return type
+// preserves the eventual async contract for callers; re-add `async` when
+// the implementation lands.
+export function expectBlocksOpenRedirect(_opts: OpenRedirectAssertion): Promise<void> {
   notImplemented('expectBlocksOpenRedirect')
 }
 
@@ -44,7 +47,8 @@ export interface MassAssignmentAssertion {
   readBack: () => Promise<Record<string, unknown>>
 }
 
-export async function expectNoMassAssignment(_opts: MassAssignmentAssertion): Promise<void> {
+// Not `async`: stub body only throws; see expectBlocksOpenRedirect above.
+export function expectNoMassAssignment(_opts: MassAssignmentAssertion): Promise<void> {
   notImplemented('expectNoMassAssignment')
 }
 


### PR DESCRIPTION
## Summary

`pnpm lint` failed on `main` with 5 errors in `src/security/index.ts` (audit-helper stubs), unrelated to any feature work. This clears them at the source:

- **Unused `_opts` (3×):** the codebase already uses the `_`-prefix convention for intentionally-unused identifiers, but `eslint.config.js` (flat config, `recommended` + `recommendedTypeChecked`) never set the ignore patterns. Added `@typescript-eslint/no-unused-vars` with `argsIgnorePattern`/`varsIgnorePattern`/`caughtErrorsIgnorePattern` = `^_` — the idiomatic config the code was clearly written to expect.
- **`require-await` (2×):** `expectBlocksOpenRedirect` / `expectNoMassAssignment` are `async` but their bodies only `throw` via `notImplemented()`. Dropped `async`; the `Promise<void>` return type preserves the eventual async contract for callers (`await` still works; a sync throw rejects the awaited promise identically). A comment notes to re-add `async` when the implementation lands.

No runtime or public-API change for consumers (stub signatures and throw behavior unchanged; the eslint config is dev-only). Treated as a chore — no version bump.

## Test plan

- [x] `pnpm lint` — green (was 5 errors, now 0)
- [x] `pnpm build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)