### PR TITLE
Bump packageManager to pnpm@11.1.3

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -220,6 +220,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/package.json
+++ b/package.json
@@ -80,5 +80,5 @@
     "dotenv": "^17.2.3",
     "pluralize-esm": "^9.0.5"
   },
-  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"
+  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  puppeteer: true


### PR DESCRIPTION
## Summary

- Bumps `packageManager` field to `pnpm@11.1.3` to match the updated local and CI pnpm version

## Test plan

- [ ] CI passes with pnpm 11

🤖 Generated with [Claude Code](https://claude.ai/claude-code)