### PR TITLE
Boot the spec server once per worker instead of once per spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- `createPsychicServer` now boots the spec server once per worker instead of re-booting a new `PsychicServer` on every spec. The previous cache was dead code (`const _server = undefined`, never reassigned), so the `if (_server) return _server` guard never fired and each spec ran a fresh `PsychicServer.boot()` — re-running application initialization and churning database/websocket connections, which made suites slow and flaky under load (ephemeral-port/connection exhaustion surfacing as intermittent `400/404/405/500` responses on unrelated specs, and websocket-layer interference on HTTP requests). The booted server is now cached on `globalThis` so it survives the per-file module-registry reset that isolating runners (e.g. Vitest with the default `isolate: true`) perform between spec files.
+
 ## 3.1.0
 
 - add `resetBrowserState()` — per-spec browser cleanup for suites that share one browser across spec files. Call it in `afterEach`: it clears `localStorage`/`sessionStorage`, clears cookies (JS-visible sweep on the current origin plus a browser-context pass for HttpOnly), and navigates to `about:blank`. Two wins: (1) real cross-spec isolation (the shared-browser setup otherwise leaks storage/cookies between specs), and (2) the `about:blank` navigation cancels in-flight requests, releasing server-side resources (e.g. a pooled DB client) so server teardown isn't blocked. Best-effort and a no-op when there is no open page, so it can never fail an unrelated spec's teardown. The shared browser is left open and reusable.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/psychic-spec-helpers",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "psychic framework spec helpers",
   "author": "RVO Health",
   "repository": {

--- a/src/unit/createPsychicServer.ts
+++ b/src/unit/createPsychicServer.ts
@@ -1,15 +1,31 @@
-// eslint-disable-next-line
-const _server: any = undefined
+// The booted spec server is cached for the lifetime of the worker process so it
+// is created and booted exactly once, then reused by every spec — instead of
+// re-booting a brand-new PsychicServer for each spec, which re-runs application
+// initialization and churns database/websocket connections (a significant
+// source of slow suites and flaky, connection-exhaustion-driven failures).
+//
+// The cache lives on `globalThis` rather than in a module-scoped variable
+// because isolating test runners (e.g. Vitest with the default `isolate: true`)
+// reset the module registry between spec files. A module-scoped cache would be
+// discarded at every file boundary, forcing a fresh boot per file; `globalThis`
+// persists for the whole worker process, so the server boots once per worker.
+const CACHED_SPEC_SERVER_KEY = Symbol.for('@rvoh/psychic-spec-helpers:cachedSpecServer')
 
 // eslint-disable-next-line
 export default async function createPsychicServer(PsychicServer: any) {
   // eslint-disable-next-line
-  if (_server) return _server!
+  const store = globalThis as Record<symbol, any>
+
+  // eslint-disable-next-line
+  if (store[CACHED_SPEC_SERVER_KEY]) return store[CACHED_SPEC_SERVER_KEY]
 
   // eslint-disable-next-line
   const server = new PsychicServer()
   // eslint-disable-next-line
   await server.boot()
+
+  // eslint-disable-next-line
+  store[CACHED_SPEC_SERVER_KEY] = server
   // eslint-disable-next-line
   return server
 }


### PR DESCRIPTION
## Problem

`createPsychicServer` is meant to cache the booted `PsychicServer`, but the cache is dead code:

```ts
const _server: any = undefined      // never reassigned
export default async function createPsychicServer(PsychicServer: any) {
  if (_server) return _server!      // never true
  const server = new PsychicServer()
  await server.boot()               // → boots a brand-new server on EVERY call
  return server
}
```

Every spec creates a fresh `OpenapiSpecRequest`/`SpecRequest` (e.g. via a `session()` helper in `beforeEach`), whose instance-level `this.server ||=` cache only covers that one test. The cross-test cache that should prevent re-booting — module-level `_server` — never fires. So a full `PsychicServer.boot()` runs **once per spec**.

Booting per spec re-runs application initialization and churns DB/websocket connections. Across a few hundred specs this is both slow and a real source of **flaky** failures under load: ephemeral-port / connection exhaustion (`connect EADDRNOTAVAIL …`) surfacing as intermittent `400/404/405/500` responses on unrelated endpoints, plus websocket-layer interference on ordinary HTTP requests.

## Fix

Cache the booted server on `globalThis` so it is created and booted **once per worker process** and reused by every spec.

`globalThis` rather than a module-level variable is required because isolating runners (e.g. Vitest with the default `isolate: true`) reset the module registry between spec files — a module-scoped cache would be discarded at each file boundary and force a fresh boot per file.

## Validation

- Reproduced on a real app suite: with the dead cache, the unit suite failed intermittently on roughly **every** full run (rotating `400/404/405/500` across unrelated controller specs). With this change, a 10× full-suite run dropped to **1 failure in 10 runs** (and that residual is an unrelated rare route race).
- `pnpm build`, `pnpm lint`, and this package's own `pnpm uspec` (55 passed) are green.

## Scope / follow-up

This makes the **server** boot once per worker, which is the dominant fix. Establishing other per-worker singletons once — notably the websocket `Redis` connection created during `PsychicApp` static init, which still runs per spec-file `beforeAll` — needs a companion change so app init (and its module-level caches) also survive per-file module isolation. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)