### PR TITLE
Add regex text content matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0
+
+- `toMatchTextContent` and `toNotMatchTextContent` now accept `RegExp` expectations, enabling direct case-insensitive text assertions such as `await expect(page).toMatchTextContent(/hello/i)`. The matcher typings now reflect the supported input shape (`string | RegExp`) instead of accepting `any`, and `toNotMatchTextContent` now forwards selector/timeout options through the Vitest matcher registration.
+
 ## 3.1.1
 
 - `createPsychicServer` now boots the spec server once per worker instead of re-booting a new `PsychicServer` on every spec. The previous cache was dead code (`const _server = undefined`, never reassigned), so the `if (_server) return _server` guard never fired and each spec ran a fresh `PsychicServer.boot()` — re-running application initialization and churning database/websocket connections, which made suites slow and flaky under load (ephemeral-port/connection exhaustion surfacing as intermittent `400/404/405/500` responses on unrelated specs, and websocket-layer interference on HTTP requests). The booted server is now cached on `globalThis` so it survives the per-file module-registry reset that isolating runners (e.g. Vitest with the default `isolate: true`) perform between spec files.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/psychic-spec-helpers",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "psychic framework spec helpers",
   "author": "RVO Health",
   "repository": {

--- a/spec/features/matchers/toMatchTextContent.spec.ts
+++ b/spec/features/matchers/toMatchTextContent.spec.ts
@@ -3,10 +3,24 @@ describe('toMatchTextContent', () => {
     await expect(page).toMatchTextContent('My div')
   })
 
+  it('succeeds when the page matches a regular expression', async () => {
+    await expect(page).toMatchTextContent(/my DIV/i)
+  })
+
+  it('succeeds when the selected element matches a regular expression', async () => {
+    await expect(page).toMatchTextContent(/my DIV/i, { selector: '#my-div' })
+  })
+
   it('fails when the page does not match the content', async () => {
     await expect(page).toMatchTextContent('My div', { timeout: 500 })
     await expect(async () => {
       await expect(page).toMatchTextContent('not found div', { timeout: 500 })
+    }).rejects.toThrow()
+  })
+
+  it('fails when the page does not match a regular expression', async () => {
+    await expect(async () => {
+      await expect(page).toMatchTextContent(/not found div/i, { timeout: 500 })
     }).rejects.toThrow()
   })
 })

--- a/spec/features/matchers/toNotMatchTextContent.spec.ts
+++ b/spec/features/matchers/toNotMatchTextContent.spec.ts
@@ -3,10 +3,20 @@ describe('toNotMatchTextContent', () => {
     await expect(page).toNotMatchTextContent('not found div', { timeout: 300 })
   })
 
+  it('succeeds when the page does not match a regular expression', async () => {
+    await expect(page).toNotMatchTextContent(/not found div/i, { timeout: 300 })
+  })
+
   it('fails when the page does match the content', async () => {
     await expect(page).toNotMatchTextContent('not found div', { timeout: 500 })
     await expect(async () => {
       await expect(page).toNotMatchTextContent('My div', { timeout: 500 })
+    }).rejects.toThrow()
+  })
+
+  it('fails when the page matches a regular expression', async () => {
+    await expect(async () => {
+      await expect(page).toNotMatchTextContent(/my DIV/i, { timeout: 500 })
     }).rejects.toThrow()
   })
 })

--- a/src/feature/helpers/providePuppeteerViteMatchers.ts
+++ b/src/feature/helpers/providePuppeteerViteMatchers.ts
@@ -15,6 +15,10 @@ import toHavePath from '../matchers/toHavePath.js'
 import toHaveSelector from '../matchers/toHaveSelector.js'
 import toHaveUnchecked from '../matchers/toHaveUnchecked.js'
 import toHaveUrl from '../matchers/toHaveUrl.js'
+import type {
+  TextContentMatcherExpected,
+  TextContentMatcherOpts,
+} from '../matchers/toMatchTextContent.js'
 import toMatchTextContent from '../matchers/toMatchTextContent.js'
 import toNotHaveSelector from '../matchers/toNotHaveSelector.js'
 import toNotMatchTextContent from '../matchers/toNotMatchTextContent.js'
@@ -35,14 +39,18 @@ export default function providePuppeteerViteMatchers() {
   ;(global as any).expect.extend({
     async toMatchTextContent(
       page: Page,
-      text: string,
-      opts?: { selector?: string } & WaitForSelectorOptions
+      text: TextContentMatcherExpected,
+      opts?: TextContentMatcherOpts
     ) {
       return await toMatchTextContent(page, text, opts)
     },
 
-    async toNotMatchTextContent(page: Page, text: string) {
-      return await toNotMatchTextContent(page, text)
+    async toNotMatchTextContent(
+      page: Page,
+      text: TextContentMatcherExpected,
+      opts?: TextContentMatcherOpts
+    ) {
+      return await toNotMatchTextContent(page, text, opts)
     },
 
     async toHaveSelector(page: Page, cssSelector: string, opts?: WaitForSelectorOptions) {

--- a/src/feature/internal/getAllTextContentFromPage.ts
+++ b/src/feature/internal/getAllTextContentFromPage.ts
@@ -1,26 +1,42 @@
 import { Page } from 'puppeteer'
 
-export default async function getAllTextContentFromPage(page: Page) {
+export default async function getAllTextContentFromPage(page: Page, selector = 'body') {
   // Evaluate and extract all text content on the page
-  const allText = await page.evaluate(() => {
+  const allText = await page.evaluate(selector => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    const elements = document.body.querySelectorAll('*')
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+    const roots = Array.from(document.querySelectorAll(selector))
 
     const textContentArray: string[] = []
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(elements as any[]).forEach(element => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      if (element.textContent.trim() !== '') {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        textContentArray.push(element.innerText.trim())
-      }
+    ;(roots as any[]).forEach(root => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+      const elements = [root, ...Array.from(root.querySelectorAll('*'))]
+
+      elements.forEach(element => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        const tagName = String(element.tagName || '').toLowerCase()
+        if (['script', 'style', 'noscript'].includes(tagName)) return
+
+        let elementText: string | undefined
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (typeof element.innerText === 'string') {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          elementText = element.innerText
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          elementText = element.textContent
+        }
+
+        const normalizedText = elementText?.trim()
+        if (normalizedText) textContentArray.push(normalizedText)
+      })
     })
 
     return textContentArray.join(' ')
-  })
+  }, selector)
 
   return allText
 }

--- a/src/feature/matchers/toMatchTextContent.ts
+++ b/src/feature/matchers/toMatchTextContent.ts
@@ -1,31 +1,41 @@
 import { Page, WaitForSelectorOptions } from 'puppeteer'
-import applyDefaultWaitForOpts from '../helpers/applyDefaultWaitForOpts.js'
+import evaluateWithRetryAndTimeout from '../internal/evaluateWithRetryAndTimeout.js'
+import getAllTextContentFromPage from '../internal/getAllTextContentFromPage.js'
+import requirePuppeteerPage from '../internal/requirePuppeteerPage.js'
+
+export type TextContentMatcherExpected = string | RegExp
+export type TextContentMatcherOpts = { selector?: string } & WaitForSelectorOptions
 
 export default async function toMatchTextContent(
-  page: Page,
-  text: string,
-  opts: { selector?: string } & WaitForSelectorOptions = {}
+  argumentPassedToExpect: Page,
+  expected: TextContentMatcherExpected,
+  opts: TextContentMatcherOpts = {}
 ) {
-  try {
-    await page.waitForSelector(
-      `${opts.selector || 'body'}::-p-text(${text.replace(/"/g, '\\"')})`,
-      applyDefaultWaitForOpts(opts)
-    )
-    return {
-      pass: true,
-      message: () => {
+  return await evaluateWithRetryAndTimeout(
+    argumentPassedToExpect,
+    async () => {
+      requirePuppeteerPage(argumentPassedToExpect)
+
+      const actual = await getAllTextContentFromPage(argumentPassedToExpect, opts.selector)
+      if (expected instanceof RegExp) expected.lastIndex = 0
+
+      return {
+        pass: typeof expected === 'string' ? actual.includes(expected) : expected.test(actual),
+        actual,
+      }
+    },
+    {
+      successText: () => {
         throw new Error('Cannot negate toMatchTextContent, use toNotMatchTextContent instead')
       },
-    }
-  } catch {
-    return {
-      pass: false,
-      message: () => `
+      failureText: actual => `
 expected ${opts.selector || 'body'} with text:
-        ${text}
+        ${expected.toString()}
 
-but no text was found within that selector
+but no matching text was found within that selector:
+        ${actual}
       `,
+      timeout: opts.timeout,
     }
-  }
+  )
 }

--- a/src/feature/matchers/toNotMatchTextContent.ts
+++ b/src/feature/matchers/toNotMatchTextContent.ts
@@ -1,21 +1,24 @@
-import { Page, WaitForSelectorOptions } from 'puppeteer'
+import { Page } from 'puppeteer'
 import evaluateWithRetryAndTimeout from '../internal/evaluateWithRetryAndTimeout.js'
 import getAllTextContentFromPage from '../internal/getAllTextContentFromPage.js'
 import requirePuppeteerPage from '../internal/requirePuppeteerPage.js'
+import type { TextContentMatcherExpected, TextContentMatcherOpts } from './toMatchTextContent.js'
 
 export default async function toNotMatchTextContent(
   argumentPassedToExpect: Page,
-  expected: string,
-  opts: WaitForSelectorOptions = {}
+  expected: TextContentMatcherExpected,
+  opts: TextContentMatcherOpts = {}
 ) {
   return await evaluateWithRetryAndTimeout(
     argumentPassedToExpect,
     async () => {
       requirePuppeteerPage(argumentPassedToExpect)
 
-      const actual = await getAllTextContentFromPage(argumentPassedToExpect)
+      const actual = await getAllTextContentFromPage(argumentPassedToExpect, opts.selector)
+      if (expected instanceof RegExp) expected.lastIndex = 0
+
       return {
-        pass: !actual.includes(expected),
+        pass: typeof expected === 'string' ? !actual.includes(expected) : !expected.test(actual),
         actual,
       }
     },
@@ -23,7 +26,7 @@ export default async function toNotMatchTextContent(
       successText: () => {
         throw new Error('Cannot negate toNotMatchTextContent, use toMatchTextContent instead')
       },
-      failureText: r => `Expected ${r} to not match text ${expected}, but it did`,
+      failureText: r => `Expected ${r} to not match text ${expected.toString()}, but it did`,
       timeout: opts.timeout,
     }
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,10 @@ import { Page, WaitForSelectorOptions } from 'puppeteer'
 import { CustomMatcherResult } from './feature/helpers/providePuppeteerViteMatchers.js'
 import { ExpectToEvaluateOpts } from './feature/internal/evaluateWithRetryAndTimeout.js'
 import { ToFillMatcherOpts } from './feature/matchers/toFill.js'
+import type {
+  TextContentMatcherExpected,
+  TextContentMatcherOpts,
+} from './feature/matchers/toMatchTextContent.js'
 export {
   RequestBody as OpenapiRequestBody,
   RequestQueryParameters as OpenapiRequestQuery,
@@ -64,10 +68,14 @@ interface PuppeteerAssertions {
   toEqualCalendarDate(expected: any): CustomMatcherResult
 
   // begin: fspec matchers
-  // eslint-disable-next-line
-  toMatchTextContent(expected: any, opts?: WaitForSelectorOptions): Promise<CustomMatcherResult>
-  // eslint-disable-next-line
-  toNotMatchTextContent(expected: any, opts?: WaitForSelectorOptions): Promise<CustomMatcherResult>
+  toMatchTextContent(
+    expected: TextContentMatcherExpected,
+    opts?: TextContentMatcherOpts
+  ): Promise<CustomMatcherResult>
+  toNotMatchTextContent(
+    expected: TextContentMatcherExpected,
+    opts?: TextContentMatcherOpts
+  ): Promise<CustomMatcherResult>
   // eslint-disable-next-line
   toHaveSelector(expected: any, opts?: WaitForSelectorOptions): Promise<CustomMatcherResult>
   // eslint-disable-next-line


### PR DESCRIPTION
## Summary
- add RegExp support to toMatchTextContent and toNotMatchTextContent for direct case-insensitive assertions
- tighten text-content matcher typings from any to string | RegExp
- forward selector/timeout options through toNotMatchTextContent registration
- bump package version to 3.2.0 and add changelog entry

## Verification
- ./node_modules/.bin/eslint --no-warn-ignored "src/**/*.ts" "spec/**/*.ts"
- ./node_modules/.bin/prettier . --check
- ./node_modules/.bin/tsc -p ./tsconfig.esm.build.json
- CI=true ./node_modules/.bin/vitest --config ./spec/features/vite.config.ts spec/features/matchers/toMatchTextContent.spec.ts spec/features/matchers/toNotMatchTextContent.spec.ts

Note: pnpm scripts attempted an implicit install/dependency status check in this no-TTY environment, so verification used the local binaries directly; feature specs used CI=true for the client dev-server pnpm child process.