### PR TITLE
Match form-control values in toMatchTextContent (fix 3.2.0 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+- `toMatchTextContent` / `toNotMatchTextContent` again match the **values** entered into form controls (`input` / `textarea`). The 3.2.0 rewrite that added `RegExp` support switched the underlying text query from Puppeteer's `::-p-text()` (which matched form-control values) to manual `innerText` extraction (which does not), silently dropping value matching and breaking specs that assert on a populated field. `getAllTextContentFromPage` now also collects `input` / `textarea` `.value`, restoring the previous behavior for both string and regex expectations.
+
 ## 3.2.0
 
 - `toMatchTextContent` and `toNotMatchTextContent` now accept `RegExp` expectations, enabling direct case-insensitive text assertions such as `await expect(page).toMatchTextContent(/hello/i)`. The matcher typings now reflect the supported input shape (`string | RegExp`) instead of accepting `any`, and `toNotMatchTextContent` now forwards selector/timeout options through the Vitest matcher registration.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,8 @@ function App() {
       <a>My link</a>
       <div id="my-div">My div</div>
       <input id="my-input" />
+      <input id="my-text-input" defaultValue="Periwinkle Tanglewood" />
+      <textarea id="my-textarea" defaultValue="Juniper Ashgrove" />
 
       <select id="select-box">
         <option>option 1</option>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/psychic-spec-helpers",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "psychic framework spec helpers",
   "author": "RVO Health",
   "repository": {

--- a/spec/features/matchers/toMatchTextContent.spec.ts
+++ b/spec/features/matchers/toMatchTextContent.spec.ts
@@ -23,4 +23,22 @@ describe('toMatchTextContent', () => {
       await expect(page).toMatchTextContent(/not found div/i, { timeout: 500 })
     }).rejects.toThrow()
   })
+
+  context('form-control values', () => {
+    it('matches an exact string within an input value', async () => {
+      await expect(page).toMatchTextContent('Periwinkle Tanglewood')
+    })
+
+    it('matches a case-insensitive regex within an input value', async () => {
+      await expect(page).toMatchTextContent(/periwinkle tanglewood/i)
+    })
+
+    it('matches an exact string within a textarea value', async () => {
+      await expect(page).toMatchTextContent('Juniper Ashgrove')
+    })
+
+    it('matches a case-insensitive regex within a textarea value', async () => {
+      await expect(page).toMatchTextContent(/juniper ashgrove/i)
+    })
+  })
 })

--- a/src/feature/internal/getAllTextContentFromPage.ts
+++ b/src/feature/internal/getAllTextContentFromPage.ts
@@ -20,6 +20,16 @@ export default async function getAllTextContentFromPage(page: Page, selector = '
         const tagName = String(element.tagName || '').toLowerCase()
         if (['script', 'style', 'noscript'].includes(tagName)) return
 
+        // Form-control values (input/textarea) are not part of innerText or
+        // textContent, but the previous ::-p-text()-based matcher matched them
+        // and callers assert on entered values, so include them explicitly.
+        if (tagName === 'input' || tagName === 'textarea') {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          const value = element.value?.trim()
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          if (value) textContentArray.push(value)
+        }
+
         let elementText: string | undefined
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (typeof element.innerText === 'string') {


### PR DESCRIPTION
## Problem

3.2.0 (`Add regex text content matching`) rewrote `toMatchTextContent` to support `RegExp` expectations. To do that, it replaced Puppeteer's `::-p-text()` text query — which **matches form-control values** — with manual `innerText` extraction (`getAllTextContentFromPage`), which does **not** include `input`/`textarea` values.

That silently dropped value matching: any spec asserting `toMatchTextContent('<a value typed into a field>')` (e.g. verifying a populated edit form) broke deterministically, with the page fully loaded.

## Fix

`getAllTextContentFromPage` now also collects `input` / `textarea` `.value` into the extracted text, so both string and regex expectations match form-control values again — restoring the pre-3.2.0 behavior while keeping the new regex support. (A `<select>`'s option text is already in `innerText`, so it's unaffected.)

## Tests

Added to `toMatchTextContent.spec.ts` (with a valued `input` + `textarea` in the client fixture), covering both axes per field type:
- exact string match within an input value
- case-insensitive regex match within an input value
- exact string match within a textarea value
- case-insensitive regex match within a textarea value

All four fail on `main`, pass with the patch. Full `fspec` (66) + `build` + `lint` green.

Patch release: 3.2.0 → 3.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)