### PR TITLE
Bump patch version for GitHub npm publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.3.0
+## 3.2.2
 
 - switch to Github action publishing to npmjs.com
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+
+- switch to Github action publishing to npmjs.com
+
 ## 3.2.1
 
 - `toMatchTextContent` / `toNotMatchTextContent` again match the **values** entered into form controls (`input` / `textarea`). The 3.2.0 rewrite that added `RegExp` support switched the underlying text query from Puppeteer's `::-p-text()` (which matched form-control values) to manual `innerText` extraction (which does not), silently dropping value matching and breaking specs that assert on a populated field. `getAllTextContentFromPage` now also collects `input` / `textarea` `.value`, restoring the previous behavior for both string and regex expectations.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/psychic-spec-helpers",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "psychic framework spec helpers",
   "author": "RVO Health",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/psychic-spec-helpers",
-  "version": "3.3.0",
+  "version": "3.2.2",
   "description": "psychic framework spec helpers",
   "author": "RVO Health",
   "publishConfig": {


### PR DESCRIPTION
Bumps the minor package version for GitHub releases and signed provenance when publishing to npmjs.com.