### PR TITLE
fix: upgrade to pnpm 11.9.0, deny build scripts in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.3
+
+- upgrade to pnpm@11.9.0; add strictDepBuilds: false and deny esbuild/puppeteer build scripts in pnpm-workspace.yaml
+
 ## 3.2.2
 
 - switch to Github action publishing to npmjs.com

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/psychic-spec-helpers",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "psychic framework spec helpers",
   "author": "RVO Health",
   "publishConfig": {
@@ -83,5 +83,5 @@
     "dotenv": "^17.2.3",
     "pluralize-esm": "^9.0.5"
   },
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+strictDepBuilds: false
+# SECURITY — allowBuilds is a supply-chain allowlist. pnpm 10+ blocks ALL
+# dependency lifecycle scripts (postinstall, etc.) by default; that default is
+# the primary defense against Shai-Hulud-class npm worms. Only packages listed
+# below (= true) may run install/build scripts. Keep this MINIMAL — every entry
+# re-opens script execution for that package, so add one only with clear cause.
 allowBuilds:
-  esbuild: true
-  puppeteer: true
+  esbuild: false
+  puppeteer: false


### PR DESCRIPTION
## Summary

- Bumps `packageManager` to `pnpm@11.9.0`
- Adds `strictDepBuilds: false` to `pnpm-workspace.yaml` so pnpm 11's hard-error on undeclared build-script deps is acknowledged explicitly
- Flips `esbuild` and `puppeteer` allowBuilds entries to `false` — esbuild ships prebuilt binaries via optional deps and puppeteer's browser is installed via an explicit CI step, so neither needs postinstall to run
- Adds the SECURITY comment explaining the allowlist's purpose
- Bumps version to `3.2.3`

## Test plan

- [ ] CI passes with pnpm 11.9.0
- [ ] No ERR_PNPM_IGNORED_BUILDS errors on install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhY4PpeeQcHTxS2kZr1n8x