### PR TITLE
Remove npx from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "uspec": "vitest --config ./spec/unit/vite.config.ts",
     "fspec": "vitest --config ./spec/features/vite.config.ts",
     "build": "echo \"building psychic-spec-helpers...\" && rm -rf dist && tsc -p ./tsconfig.esm.build.json",
-    "build:test-app": "rm -rf dist && echo \"building test app to esm...\" && tsc -p ./tsconfig.esm.build.test-app.json && echo \"building test app to cjs...\" && npx tsc -p ./tsconfig.cjs.build.test-app.json",
+    "build:test-app": "rm -rf dist && echo \"building test app to esm...\" && tsc -p ./tsconfig.esm.build.test-app.json && echo \"building test app to cjs...\" && tsc -p ./tsconfig.cjs.build.test-app.json",
     "lint": "pnpm eslint --no-warn-ignored \"src/**/*.ts\" \"spec/**/*.ts\" && pnpm prettier . --check",
     "format": "pnpm prettier . --write",
     "prepack": "pnpm build"


### PR DESCRIPTION
## Summary
- remove the unnecessary npx prefix from the build:test-app TypeScript command
- rely on npm-script PATH resolution for the local tsc binary

## Verification
- rg npx package-script scan across published @rvoh packages in this workspace
- CI=true pnpm lint
- pnpm build

## Note
- pnpm build:test-app still fails before the changed command runs due to an existing vitest/globals type-resolution issue in the ESM test-app config.