### PR TITLE
launchDevServer: actually wait for the server; surface spawn/death failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.3.0
+
+- `launchDevServer` fixes:
+  - `waitForPort`'s polarity was inverted — it resolved as soon as the port was _free_, i.e. before the dev server had bound it, so it never actually waited; feature suites only passed when the server won the race against the first navigation. It now waits until something is listening on the port. Because the timeout is now real, the default `timeout` rises from `5000` to `30000` to accommodate genuine dev-server cold starts (pass `timeout` explicitly if you want the old bound).
+  - spawn failures (e.g. command not found) previously emitted `'error'` with no listener (both listeners were attached only after awaiting the port) and crashed the vitest worker with an uncaughtException; one of the two duplicate listeners also re-threw inside the handler. `launchDevServer` now rejects with a comprehensible error when the command cannot be spawned, when the process exits before ever listening, and when the port is not bound within the timeout.
+  - a dev server that dies mid-suite was logged only under `DEBUG=1`, surfacing as opaque navigation timeouts; it is now logged unconditionally and evicted from the process cache, so `stopDevServers` teardown no longer throws on the dead entry and a later `launchDevServer` with the same key can relaunch.
+- typing: the custom puppeteer matchers are now declared on vitest's `Matchers` interface (the vitest ≥ 3.2 augmentation point) instead of `Assertion`/`ExpectStatic`, which vitest 4 no longer merges — restoring `expect(page).toMatchTextContent(...)`-style typing under vitest 4.
+- typing: the package no longer declares the global `context`; `@rvoh/dream-spec-helpers` (present in every psychic app) already declares the identical global, and the duplicate declaration is a TS2451 redeclare error in any program that type-checks both declarations together.
+- internal: repair the long-broken `pnpm build:test-app` (never run in CI): remove the bogus `typeRoots` override that blocked `vitest/globals` resolution, fix test-app cors `origin` to psychic v3's `string | fn` type, and drop the CJS half of the test-app build — it cannot compile (ESM-only repo importing subpath exports under `moduleResolution: "Node"`) and type-checked an artifact the ESM-only publish build never produces.
+
 ## 3.2.3
 
 - upgrade to pnpm@11.9.0; add strictDepBuilds: false and deny esbuild/puppeteer build scripts in pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "uspec": "vitest --config ./spec/unit/vite.config.ts",
     "fspec": "vitest --config ./spec/features/vite.config.ts",
     "build": "echo \"building psychic-spec-helpers...\" && rm -rf dist && tsc -p ./tsconfig.esm.build.json",
-    "build:test-app": "rm -rf dist && echo \"building test app to esm...\" && tsc -p ./tsconfig.esm.build.test-app.json && echo \"building test app to cjs...\" && tsc -p ./tsconfig.cjs.build.test-app.json",
+    "build:test-app": "rm -rf dist && echo \"building test app to esm...\" && tsc -p ./tsconfig.esm.build.test-app.json",
     "lint": "pnpm eslint --no-warn-ignored \"src/**/*.ts\" \"spec/**/*.ts\" && pnpm prettier . --check",
     "format": "pnpm prettier . --write",
     "prepack": "pnpm build"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/psychic-spec-helpers",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "psychic framework spec helpers",
   "author": "RVO Health",
   "publishConfig": {

--- a/spec/features/resetBrowserState.spec.ts
+++ b/spec/features/resetBrowserState.spec.ts
@@ -1,22 +1,28 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
-// ^ this spec drives DOM globals (document/localStorage) inside page.evaluate;
-//   the spec tsconfig has no DOM lib, so they type as `any` here.
 import { resetBrowserState } from '../../src/index.js'
+
+// `document` isn't in the Node lib this package is type-checked against; these
+// evaluate callbacks run in the browser, so pull it off globalThis with a cast
+// (same idiom as src/feature/helpers/resetBrowserState.ts)
+type DocumentGlobal = { document: { cookie: string } }
 
 describe('resetBrowserState', () => {
   it('clears localStorage/sessionStorage and cookies and navigates to about:blank', async () => {
     await visit('/')
 
     await page.evaluate(() => {
+      const { document } = globalThis as unknown as DocumentGlobal
       localStorage.setItem('token', 'secret')
       sessionStorage.setItem('flash', 'hi')
       document.cookie = 'session=abc; path=/'
     })
 
-    const before = (await page.evaluate(() => ({
-      ls: localStorage.getItem('token'),
-      cookie: document.cookie,
-    }))) as { ls: string | null; cookie: string }
+    const before = await page.evaluate(() => {
+      const { document } = globalThis as unknown as DocumentGlobal
+      return {
+        ls: localStorage.getItem('token'),
+        cookie: document.cookie,
+      }
+    })
     expect(before.ls).toEqual('secret')
     expect(before.cookie).toContain('session=abc')
 
@@ -25,11 +31,14 @@ describe('resetBrowserState', () => {
     expect(page.url()).toEqual('about:blank')
 
     await visit('/')
-    const after = (await page.evaluate(() => ({
-      ls: localStorage.getItem('token'),
-      ss: sessionStorage.getItem('flash'),
-      cookie: document.cookie,
-    }))) as { ls: string | null; ss: string | null; cookie: string }
+    const after = await page.evaluate(() => {
+      const { document } = globalThis as unknown as DocumentGlobal
+      return {
+        ls: localStorage.getItem('token'),
+        ss: sessionStorage.getItem('flash'),
+        cookie: document.cookie,
+      }
+    })
     expect(after.ls).toBeNull()
     expect(after.ss).toBeNull()
     expect(after.cookie).not.toContain('session=abc')

--- a/spec/unit/launchDevServer/fixtures/exitWithCode.js
+++ b/spec/unit/launchDevServer/fixtures/exitWithCode.js
@@ -1,0 +1,2 @@
+// spec fixture: exits immediately with the given code, never listening on any port
+process.exit(Number(process.argv[2] ?? 1))

--- a/spec/unit/launchDevServer/fixtures/listenAfterDelay.js
+++ b/spec/unit/launchDevServer/fixtures/listenAfterDelay.js
@@ -1,0 +1,10 @@
+// spec fixture: binds a tcp server on the given port after an optional delay,
+// then stays alive until killed
+import { createServer } from 'net'
+
+const port = Number(process.argv[2])
+const delayMs = Number(process.argv[3] ?? 0)
+
+setTimeout(() => {
+  createServer().listen(port, '127.0.0.1')
+}, delayMs)

--- a/spec/unit/launchDevServer/fixtures/listenThenExit.js
+++ b/spec/unit/launchDevServer/fixtures/listenThenExit.js
@@ -1,0 +1,13 @@
+// spec fixture: binds a tcp server on the given port immediately, then exits
+// with the given code after the given lifespan (simulates a dev server dying mid-suite)
+import { createServer } from 'net'
+
+const port = Number(process.argv[2])
+const lifespanMs = Number(process.argv[3] ?? 300)
+const exitCode = Number(process.argv[4] ?? 0)
+
+createServer().listen(port, '127.0.0.1')
+
+setTimeout(() => {
+  process.exit(exitCode)
+}, lifespanMs)

--- a/spec/unit/launchDevServer/fixtures/neverListen.js
+++ b/spec/unit/launchDevServer/fixtures/neverListen.js
@@ -1,0 +1,2 @@
+// spec fixture: stays alive but never listens on any port
+setInterval(() => {}, 1000)

--- a/spec/unit/launchDevServer/launchDevServer.spec.ts
+++ b/spec/unit/launchDevServer/launchDevServer.spec.ts
@@ -1,0 +1,108 @@
+import { connect } from 'net'
+import { launchDevServer, stopDevServer, stopDevServers } from '../../../src/index.js'
+import sleep from '../../../src/shared/sleep.js'
+
+const FIXTURES = 'spec/unit/launchDevServer/fixtures'
+
+async function isPortListening(port: number): Promise<boolean> {
+  return await new Promise(resolve => {
+    const socket = connect({ port, host: '127.0.0.1' })
+      .once('connect', () => {
+        socket.destroy()
+        resolve(true)
+      })
+      .once('error', () => {
+        resolve(false)
+      })
+  })
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number = 3000) {
+  const startTime = Date.now()
+  while (!predicate()) {
+    if (Date.now() > startTime + timeoutMs) throw new Error('waitFor timed out')
+    await sleep(50)
+  }
+}
+
+describe('launchDevServer', () => {
+  afterEach(() => {
+    try {
+      stopDevServers()
+    } catch {
+      // specs assert on server lifecycle themselves; cleanup is best-effort
+    }
+  })
+
+  it('resolves once the dev server is actually listening on the port, even when the server takes a moment to bind', async () => {
+    await launchDevServer('delayed-bind', {
+      port: 33431,
+      cmd: `node ${FIXTURES}/listenAfterDelay.js 33431 500`,
+      timeout: 10000,
+    })
+
+    expect(await isPortListening(33431)).toBe(true)
+  })
+
+  it('rejects with a comprehensible error when the command cannot be spawned', async () => {
+    await expect(
+      launchDevServer('bad-command', {
+        port: 33432,
+        cmd: 'nonexistent-command-cba0e2b19c',
+        timeout: 10000,
+      })
+    ).rejects.toThrow(/failed to start/)
+  })
+
+  it('rejects when the process exits before ever listening on the port', async () => {
+    await expect(
+      launchDevServer('early-exit', {
+        port: 33433,
+        cmd: `node ${FIXTURES}/exitWithCode.js 7`,
+        timeout: 10000,
+      })
+    ).rejects.toThrow(/exited with code 7 before listening on port 33433/)
+  })
+
+  it('rejects when the process never listens on the port within the timeout', async () => {
+    await expect(
+      launchDevServer('never-listens', {
+        port: 33434,
+        cmd: `node ${FIXTURES}/neverListen.js`,
+        timeout: 500,
+      })
+    ).rejects.toThrow(/did not listen on port 33434 within 500ms/)
+  })
+
+  context('when the dev server dies mid-suite', () => {
+    it('logs the death without DEBUG=1 and evicts the process so it is not treated as still running', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await launchDevServer('mid-suite-death', {
+        port: 33435,
+        cmd: `node ${FIXTURES}/listenThenExit.js 33435 300 9`,
+        timeout: 10000,
+      })
+
+      await waitFor(() =>
+        consoleErrorSpy.mock.calls.some(args =>
+          /exited unexpectedly with code 9/.test(String(args[0]))
+        )
+      )
+
+      expect(() => stopDevServer('mid-suite-death')).toThrow(/Cannot find a dev server/)
+    })
+  })
+
+  it('launches and stops a dev server that binds immediately', async () => {
+    await launchDevServer('happy-path', {
+      port: 33436,
+      cmd: `node ${FIXTURES}/listenAfterDelay.js 33436 0`,
+      timeout: 10000,
+    })
+    expect(await isPortListening(33436)).toBe(true)
+
+    stopDevServer('happy-path')
+    expect(() => stopDevServer('happy-path')).toThrow(/Cannot find a dev server/)
+  })
+})

--- a/src/feature/helpers/launchDevServer.ts
+++ b/src/feature/helpers/launchDevServer.ts
@@ -9,7 +9,7 @@ export default async function launchDevServer(
   {
     port = 3000,
     cmd = 'pnpm client',
-    timeout = 5000,
+    timeout = 30000,
   }: { port?: number; cmd?: string; timeout?: number } = {}
 ) {
   if (devServerProcesses[key]) return
@@ -28,10 +28,15 @@ export default async function launchDevServer(
 
   devServerProcesses[key] = proc
 
-  await waitForPort(key, port, timeout)
+  let spawnError: Error | undefined
+  let exited = false
+  let exitCode: number | null = null
 
+  // attached before any await so that an immediate spawn failure (e.g. ENOENT)
+  // cannot emit 'error' with no listener and crash the process
   proc.on('error', err => {
-    throw err
+    spawnError = err
+    console.error(`Dev server "${key}" (\`${cmd}\`) process error: ${err.message}`)
   })
 
   proc.stdout.on('data', data => {
@@ -42,13 +47,43 @@ export default async function launchDevServer(
     if (process.env.DEBUG === '1') console.error(`Server error: ${data}`)
   })
 
-  proc.on('error', err => {
-    console.error(`Server process error: ${err as unknown as string}`)
+  proc.on('close', code => {
+    exited = true
+    exitCode = code
+
+    if (devServerProcesses[key] === proc) {
+      // the process died on its own (it was not stopped via stopDevServer); evict it
+      // so it is not treated as still running, and log unconditionally so specs that
+      // subsequently fail on a dead dev server are comprehensible
+      delete devServerProcesses[key]
+      if (!spawnError)
+        console.error(`Dev server "${key}" (\`${cmd}\`) exited unexpectedly with code ${code}`)
+    } else if (process.env.DEBUG === '1') {
+      console.log(`Server process exited with code ${code}`)
+    }
   })
 
-  proc.on('close', code => {
-    if (process.env.DEBUG === '1') console.log(`Server process exited with code ${code}`)
-  })
+  try {
+    await waitForPort(key, cmd, port, timeout, () => {
+      if (spawnError)
+        return new Error(
+          `Dev server "${key}" (\`${cmd}\`) failed to start: ${spawnError.message}`,
+          {
+            cause: spawnError,
+          }
+        )
+
+      if (exited)
+        return new Error(
+          `Dev server "${key}" (\`${cmd}\`) exited with code ${exitCode} before listening on port ${port}`
+        )
+
+      return undefined
+    })
+  } catch (err) {
+    if (devServerProcesses[key] === proc) delete devServerProcesses[key]
+    throw err
+  }
 }
 
 export function stopDevServer(key: string) {
@@ -59,9 +94,11 @@ export function stopDevServer(key: string) {
 
   if (proc?.pid) {
     if (process.env.DEBUG === '1') console.log('Stopping server...')
+    // delete before killing so the 'close' listener can distinguish an intentional
+    // stop from the dev server dying on its own
+    delete devServerProcesses[key]
     // serverProcess.kill('SIGINT')
     process.kill(-proc.pid, 'SIGKILL')
-    delete devServerProcesses[key]
 
     if (process.env.DEBUG === '1') console.log('server stopped')
   }
@@ -91,26 +128,28 @@ async function isPortAvailable(port: number): Promise<boolean> {
   })
 }
 
-async function waitForPort(key: string, port: number, timeout: number = 5000) {
-  if (await isPortAvailable(port)) {
-    return true
-  }
-
+async function waitForPort(
+  key: string,
+  cmd: string,
+  port: number,
+  timeout: number,
+  abortError: () => Error | undefined
+) {
   const startTime = Date.now()
 
-  async function recursiveWaitForPort() {
-    if (await isPortAvailable(port)) {
-      return true
-    }
+  // the port being available means nothing is listening on it yet,
+  // so keep waiting until the dev server has actually bound it
+  while (await isPortAvailable(port)) {
+    const error = abortError()
+    if (error) throw error
 
     if (Date.now() > startTime + timeout) {
-      stopDevServer(key)
-      throw new Error('waited too long for port: ' + port)
+      if (devServerProcesses[key]) stopDevServer(key)
+      throw new Error(
+        `Dev server "${key}" (\`${cmd}\`) did not listen on port ${port} within ${timeout}ms`
+      )
     }
 
     await sleep(50)
-    return await recursiveWaitForPort()
   }
-
-  return await recursiveWaitForPort()
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,11 @@ export { default as resetBrowserState } from './feature/helpers/resetBrowserStat
 export { default as visit } from './feature/helpers/visit.js'
 
 declare global {
-  const context: (typeof import('vitest'))['describe']
+  // `context` is deliberately NOT declared here: @rvoh/dream-spec-helpers (always
+  // present alongside this package in a psychic app) already declares it, and a
+  // second declaration is a TS2451 redeclare error whenever both declarations are
+  // checked in one program (e.g. this repo's own test-app build, where this file
+  // is source rather than a skipLibCheck-suppressed .d.ts).
 
   const page: InstanceType<typeof Page>
   const visit: (typeof import('./feature/helpers/visit.js'))['default']
@@ -51,10 +55,10 @@ declare global {
 }
 
 declare module 'vitest' {
+  // vitest >= 3.2 matcher augmentation point (covers expect(), expect.soft, asymmetric
+  // matchers); augmenting Assertion/ExpectStatic no longer merges under vitest 4
   // eslint-disable-next-line
-  interface ExpectStatic extends PuppeteerAssertions {}
-  // eslint-disable-next-line
-  interface Assertion extends PuppeteerAssertions {}
+  interface Matchers<T = any> extends PuppeteerAssertions {}
 }
 
 interface PuppeteerAssertions {

--- a/test-app/src/conf/app.ts
+++ b/test-app/src/conf/app.ts
@@ -47,7 +47,7 @@ export default async (psy: PsychicApp) => {
   // set options to pass to coors when middleware is booted
   psy.set('cors', {
     credentials: true,
-    origin: [process.env.CLIENT_HOST || 'http://localhost:3000'],
+    origin: process.env.CLIENT_HOST || 'http://localhost:3000',
   })
 
   // set options for cookie usage

--- a/tsconfig.cjs.build.test-app.json
+++ b/tsconfig.cjs.build.test-app.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.cjs.build.json",
-  "include": ["src/**/*", "test-app/**/*", "spec/**/*"],
-  "exclude": ["spec/support/**/*", "spec/tmp/**/*"],
-
-  "compilerOptions": {
-    "typeRoots": ["spec/global.d.ts"]
-  }
-}

--- a/tsconfig.esm.build.test-app.json
+++ b/tsconfig.esm.build.test-app.json
@@ -1,9 +1,5 @@
 {
   "extends": "./tsconfig.esm.build.json",
   "include": ["src/**/*", "test-app/**/*", "spec/**/*"],
-  "exclude": ["spec/support/**/*", "spec/tmp/**/*"],
-
-  "compilerOptions": {
-    "typeRoots": ["spec/global.d.ts"]
-  }
+  "exclude": ["spec/support/**/*", "spec/tmp/**/*"]
 }


### PR DESCRIPTION
## What

Error-observability fixes for `launchDevServer` (`src/feature/helpers/launchDevServer.ts`), plus repair of the long-broken `pnpm build:test-app`.

### `waitForPort` polarity (confirmed, not just sweep-reported)

`waitForPort` resolved when the port was **free** (`isPortAvailable === true`), i.e. before the dev server had bound it — typically immediately. It never actually waited; feature suites only passed when the dev server won the race against the first navigation. It now polls until something is listening on the port. Because the timeout is now real (previously it could only fire when a foreign process already held the port), the default rises from 5s to 30s to accommodate genuine dev-server cold starts.

### Child-process error handling

Previously:
- both `'error'` listeners were attached *after* awaiting the port, so an immediate spawn failure (ENOENT) emitted `'error'` with no listener and crashed the vitest worker (reproduced by the new spec against the old code);
- one of the two duplicate listeners re-threw inside the event handler — an uncaughtException by construction;
- child death was logged only under `DEBUG=1`, so a dev server crashing mid-suite surfaced as opaque navigation timeouts.

Now: listeners attach synchronously before any await; `launchDevServer` rejects with a comprehensible error when the command cannot be spawned, when the process exits before ever listening, and when the port is not bound within the timeout; a dev server dying after launch is logged unconditionally and evicted from the process cache (so `stopDevServers` teardown does not throw on the dead entry and a later `launchDevServer` can relaunch).

### BDD

New `spec/unit/launchDevServer/launchDevServer.spec.ts` (6 specs, driving the real helper against tiny spawned fixture scripts) — all written first and watched fail against the old implementation, including the uncaughtException crash on the spawn-failure path. Even the "binds immediately" happy path failed before the fix, since `launchDevServer` resolved before the bind.

### Pre-existing `build:test-app` drift (first commit)

`pnpm build:test-app` fails on a clean checkout of main (verified via detached worktree; CI only runs `pnpm build`): a `typeRoots` override pointing at a *file* blocked `vitest/globals` resolution; the global `context` declaration collides (TS2451) with @rvoh/dream-spec-helpers' identical one when src+spec compile together; vitest 4 no longer merges `Assertion`/`ExpectStatic` augmentations (moved to the vitest ≥3.2 `Matchers` interface); test-app cors `origin` array vs psychic v3's `string | fn` (same drift as psychic-workers #73/#74, psychic-websockets #64); bare `document` in spec `page.evaluate` callbacks. The CJS half of the test-app build is dropped: it cannot compile as configured (`"type": "module"` repo + subpath exports under `moduleResolution: "Node"`, and TS forbids `module: CommonJS` with `moduleResolution: node16`), and the publish build (`pnpm build`/`prepack`) has been ESM-only all along.

## Verification

- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm build:test-app` ✅ (fails on clean main)
- `pnpm uspec` ✅ (21 files / 61 specs)
- `pnpm fspec` ✅ (26 files / 66 specs, exit 0)

(uspec/fspec run with `PORT=7877` locally to dodge an unrelated local process squatting `.env.test`'s `:7777`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)